### PR TITLE
FIX: LED could be off after wifi connect and enabled accel by default

### DIFF
--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -57,7 +57,6 @@ void OpenBCI_Ganglion::initialize() {
   rssiTimer = millis();
 }
 
-
 void OpenBCI_Ganglion::makeUniqueId() {
   uint64_t id = getDeviceId();
   String stringy =  String(getDeviceIdLow(), HEX);
@@ -68,7 +67,7 @@ void OpenBCI_Ganglion::makeUniqueId() {
   SimbleeBLE.manufacturerName = "openbci.com";
   SimbleeBLE.modelNumber = "Ganglion";
   SimbleeBLE.hardwareRevision = "1.0.1";
-  SimbleeBLE.softwareRevision = "2.0.0";
+  SimbleeBLE.softwareRevision = "2.0.0-rc2";
 }
 
 void OpenBCI_Ganglion::blinkLED() {

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,20 @@
 
 * Changed MCP3912 setup to NOT accept sample rate passed into it
 
+## Release Candidate 2
+
+### Bug Fixes
+
+* LED light could have held in off state if connected to wifi shield while LED is off.
+
+### Enhancements
+
+* Accelerometer enabled by default with wifi.
+
+## Release Candidate 1
+
+Initial release candidate
+
 ## Beta4
 
 ### Enhancements

--- a/examples/DefaultGanglion/DefaultGanglion.ino
+++ b/examples/DefaultGanglion/DefaultGanglion.ino
@@ -53,6 +53,10 @@ void loop() {
 
   if (!wifi.sentGains) {
     if(wifi.present && wifi.tx) {
+      ganglion.useAccel = true;
+      ganglion.enable_LIS2DH();
+      ganglion.LED_state = true;
+      digitalWrite(ganglion.LED, HIGH);
       wifi.sendGains(4, ganglion.getGains());
     }
   }

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-OpenBCI_Ganglion_Library	KEYWORD1
+ganglion	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -17,6 +17,11 @@ blinkLED	KEYWORD2
 eventSerial	KEYWORD2
 testImpedance	KEYWORD2
 MCP_ISR		KEYWORD2
+enable_LIS2DH KEYWORD2
+useAccel KEYWORD2
+LED_state KEYWORD2
+LED KEYWORD2
+getGains KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_Ganglion_Library
-version=2.0.0-rc1
+version=2.0.0-rc2
 author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
 maintainer=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
 sentence=The library for OpenBCI Ganglion board. Please use the DefaultGanglion.ino file in the examples to use the code that ships with every Ganglion board. Look through the skimmed down versions of the main firmware in the other examples.


### PR DESCRIPTION
# v2.0.0

### New Features

* Added Wifi Shield Compatibility
* Added ability to change sample rates

### Breaking Changes

* Changed MCP3912 setup to NOT accept sample rate passed into it

## Release Candidate 2

### Bug Fixes

* LED light could have held in off state if connected to wifi shield while LED is off.

### Enhancements

* Accelerometer enabled by default with wifi.

## Release Candidate 1

Initial release candidate

## Beta4

### Enhancements

* Needed to update sample rate setting functions to match the Cyton responses and thus work with wifi drivers.
* Add more helper printing functions to reduce code string foot prints such as `::printSampleRate()`, `::printFailure()`, and `::printSuccess()`

## Beta3

### New Features

* Send gains after connecting to Wifi shield

## Beta2

The overall goal was to clean the wifi code out of the library so it would not be needed when you are building a bare board.

### Bug Fixes

* Weird timing issue with wifi shield

### Breaking Changes

* Removed all wifi code and put into [new library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library) that must be included! The new library is a called [OpenBCI_Wifi_Master_Library](https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library). It is simply included when wifi is wanted.
* Removed `.loop()` function from library and all other `wifi*.()` functions.
* `DefaultGanglion.ino` now has wifi code.

### Files

* Removed `WifiGanglion.ino`
* Add `GanglionNoWifi.ino` example

## Beta1

* Initial release with wifi