### PR TITLE
FIX: adding delay between spi multi chars helps with stability

### DIFF
--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -67,7 +67,7 @@ void OpenBCI_Ganglion::makeUniqueId() {
   SimbleeBLE.manufacturerName = "openbci.com";
   SimbleeBLE.modelNumber = "Ganglion";
   SimbleeBLE.hardwareRevision = "1.0.1";
-  SimbleeBLE.softwareRevision = "2.0.0";
+  SimbleeBLE.softwareRevision = "2.0.1";
 }
 
 void OpenBCI_Ganglion::blinkLED() {
@@ -1016,6 +1016,7 @@ void OpenBCI_Ganglion::loadNewLine() {
   if (commandFromSPI) {
     if (wifi.present && wifi.tx) {
       wifi.sendStringMulti("\n");
+      delay(1);
     }
   } else {
     serialBuffer[bufferLevel][serialIndex[bufferLevel]] = '\n';
@@ -1030,6 +1031,7 @@ void OpenBCI_Ganglion::loadString(const char* thatString, int numChars, boolean 
   if (commandFromSPI) {
     if (wifi.present && wifi.tx) {
       wifi.sendStringMulti(thatString);
+      delay(1);
     }
   } else {
     for (int i = 0; i < numChars; i++) {
@@ -1082,6 +1084,7 @@ void OpenBCI_Ganglion::loadChar(char thatChar, boolean addNewLine) {
   if (commandFromSPI) {
     if (wifi.present && wifi.tx) {
       wifi.sendStringMulti(&thatChar);
+      delay(1);
     }
   } else {
     serialBuffer[bufferLevel][serialIndex[bufferLevel]] = thatChar;
@@ -1131,6 +1134,7 @@ void OpenBCI_Ganglion::loadInt(int i, boolean addNewLine) {
     if (commandFromSPI) {
       if (wifi.present && wifi.tx) {
         wifi.sendStringMulti(digit[i]);
+        delay(1);
       }
     } else {
       serialBuffer[bufferLevel][serialIndex[bufferLevel]] = digit[i];

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v2.0.1
+
+### Bug Fixes
+
+* Adding a delay after sending multipacket spi messages improves reliability! Some messages like sample rate got chopped up :rocket:
+
 # v2.0.0
 
 ### New Features

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_Ganglion_Library
-version=2.0.0
+version=2.0.1
 author=Joel Murphy <joel@openbci.com>, Conor Russomanno <conor@openbci.com>, Leif Percifield <lpercifield@gmail.com>, AJ Keller <pushtheworldllc@gmail.com>
 maintainer=Joel Murphy <joel@openbci.com>, AJ Keller <pushtheworldllc@gmail.com>
 sentence=The library for OpenBCI Ganglion board. Please use the DefaultGanglion.ino file in the examples to use the code that ships with every Ganglion board. Look through the skimmed down versions of the main firmware in the other examples.


### PR DESCRIPTION
# v2.0.1

### Bug Fixes

* Adding a delay after sending multipacket spi messages improves reliability! Some messages like sample rate got chopped up :rocket: