### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,11 +17,11 @@ blinkLED	KEYWORD2
 eventSerial	KEYWORD2
 testImpedance	KEYWORD2
 MCP_ISR		KEYWORD2
-enable_LIS2DH KEYWORD2
-useAccel KEYWORD2
-LED_state KEYWORD2
-LED KEYWORD2
-getGains KEYWORD2
+enable_LIS2DH	KEYWORD2
+useAccel	KEYWORD2
+LED_state	KEYWORD2
+LED	KEYWORD2
+getGains	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords