### PR TITLE
Fix restarting data steam bug

### DIFF
--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -67,7 +67,7 @@ void OpenBCI_Ganglion::makeUniqueId() {
   SimbleeBLE.manufacturerName = "openbci.com";
   SimbleeBLE.modelNumber = "Ganglion";
   SimbleeBLE.hardwareRevision = "1.0.1";
-  SimbleeBLE.softwareRevision = "3.0.0";
+  SimbleeBLE.softwareRevision = "3.0.1";
 }
 
 void OpenBCI_Ganglion::blinkLED() {

--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -239,9 +239,9 @@ void OpenBCI_Ganglion::incrementSyntheticChannelData() {
     for (int i = 0; i < 4; i++) {
       rising[i] = !rising[i];
       if (rising[i]) {
-        channelData[i] = 8000;
+        channelData[i] = 8000000;
       } else {
-        channelData[i] = -8000;
+        channelData[i] = -8000000;
       }
     }
   }

--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -131,6 +131,7 @@ boolean OpenBCI_Ganglion::startRunning(void) {
     }
     is_running = true;
     sampleCounter = 0xFF;
+    ringBufferLevel = 0xFF;
     if (streamSynthetic) {
       for (int i = 1; i < 4; i++) {
         channelData[i] = 0;
@@ -930,7 +931,7 @@ boolean OpenBCI_Ganglion::eventSerial() {
         if (bufferLevelCounter == bufferLevel + 1) { // when we send all the packets
           serialBytesToSend = false;                    // put down bufferToSend flag
           bufferLevel = 0;                        // initialize bufferLevel
-          initSerialBuffer();                     // initialize bufffer
+          initSerialBuffer();                     // initialize buffer
         }
         timeLastPacketSent = millis();
       }
@@ -943,7 +944,7 @@ boolean OpenBCI_Ganglion::eventSerial() {
       }
       serialBytesToSend = false;                    // put down bufferToSend flag
       bufferLevel = 0;                        // initialize bufferLevel
-      initSerialBuffer();                     // initialize bufffer
+      initSerialBuffer();                     // initialize buffer
     }
   }
 


### PR DESCRIPTION
- Increased the synthetic channel voltage to further stress compression algorithm.
- Fixed a bug that prevented the data stream from restarting. There are two counters that are used to track the packet ID and the acquired sample. The sample counter was reset when starting a stream, but the packet ID was not.