### PR TITLE
Fix noisy data on channel 4 with accelerometer enabled

### DIFF
--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -293,7 +293,7 @@ void OpenBCI_Ganglion::compressData18()
     compression_ring[ringBufferLevel][13] |= ((channelData[2] & 0x0003C000) >> 14);
     compression_ring[ringBufferLevel][14] = ((channelData[2] & 0x00003FC0) >> 6);
     compression_ring[ringBufferLevel][15] = ((channelData[2] & 0x0000003F) << 2);
-    compression_ring[ringBufferLevel][16] |= ((channelData[3] & 0x00030000) >> 16);
+    compression_ring[ringBufferLevel][15] |= ((channelData[3] & 0x00030000) >> 16);
     compression_ring[ringBufferLevel][16] = ((channelData[3] & 0x0000FF00) >> 8);
     compression_ring[ringBufferLevel][17] = ((channelData[3] & 0x000000FF));
 


### PR DESCRIPTION
Below are screenshots of the updated firmware running against the OpenBCI GUI version 5.2.2. The test drives a 10Hz sine wave through channel for of the Ganglion.

With the accelerometer enabled (fixed)
![image](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/assets/84428015/220776d1-0e91-4b97-9149-b546882f1507)

With the accelerometer disabled (was already working)
![image](https://github.com/OpenBCI/OpenBCI_Ganglion_Library/assets/84428015/360f8d91-c442-42f6-ab43-1ee6ea489668)
