### PR TITLE
Fix macOS native BLE firmware detection

### DIFF
--- a/OpenBCI_Ganglion_Library.cpp
+++ b/OpenBCI_Ganglion_Library.cpp
@@ -67,7 +67,8 @@ void OpenBCI_Ganglion::makeUniqueId() {
   SimbleeBLE.manufacturerName = "openbci.com";
   SimbleeBLE.modelNumber = "Ganglion";
   SimbleeBLE.hardwareRevision = "1.0.1";
-  SimbleeBLE.softwareRevision = "3.0.2";
+  SimbleeBLE.softwareRevision = "3.0.3";
+  SimbleeBLE.deviceName = "Ganglion 1.3";
 }
 
 void OpenBCI_Ganglion::blinkLED() {


### PR DESCRIPTION
On some macOS machines, the device appears as "Simblee" when using native BLE. This causes problems with the current firmware version discovery procedure which attempts to process the firmware version from the device name. 

This PR sets the Device Name characteristic in the Generic Access service that was previously left unset. It appears that this defaults to "Simblee" so there's a reasonable chance that this is what macOS native BLE is reading.